### PR TITLE
Fix bug with [ ] in form names - escape special chars in selectors

### DIFF
--- a/lc_switch.js
+++ b/lc_switch.js
@@ -54,6 +54,8 @@
 				if( $wrap.find('.lcs_switch').hasClass('lcs_radio_switch') ) {
 					
 					var f_name = $input.attr('name');
+					// escape f_name, source: http://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/
+					f_name = f_name.replace( /(:|\.|\[|\]|,|=|@)/g, '\\$1' );
 					$wrap.parents('form').find('input[name='+f_name+']').not($input).lcs_off();	
 				}
             });


### PR DESCRIPTION
Hi,

We got crashes when you used [] in input names that was radios, for example something like this:
```html
<input type="radio" id="account_type_change_version_0" name="account_type_change[version]" required="required" value="4">
```

That was because [] was used in the CSS selectors. This PR escapes all special chars with \\ before, and works good for us.