### PR TITLE
Corrected thrown event name

### DIFF
--- a/lc_switch.js
+++ b/lc_switch.js
@@ -257,7 +257,7 @@
             
             // trigger events
             if(!forced_action) {
-                const lcsOnEvent = new Event("lcs-off"),
+                const lcsOnEvent = new Event("lcs-on"),
                       lcsStatusChangeEvent = new Event('lcs-statuschange');
 
                 el.dispatchEvent(lcsOnEvent);


### PR DESCRIPTION
On activate a switch i threw an lcs-off event. Now it hrows an lcs-on event